### PR TITLE
Filter m.room.join_rules content to only expose join_rule key

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ This allows clients to:
 
 **Backwards Compatibility:** The `membership_summary` field is additive and only appears when activity roles are present. Existing clients that don't use this field will continue to work without modification, as the core response structure remains unchanged.
 
+#### Content Filtering for m.room.join_rules
+
+When returning `m.room.join_rules` state events, the module filters the content to only include the `join_rule` key. All other keys (such as `allow` for restricted rooms) are stripped from the response for security and privacy reasons.
+
+Example response for a room with join_rules:
+```json
+{
+  "rooms": {
+    "!room_id:example.com": {
+      "m.room.join_rules": {
+        "default": {
+          "content": {
+            "join_rule": "knock"
+          },
+          "type": "m.room.join_rules",
+          "state_key": ""
+        }
+      }
+    }
+  }
+}
+```
+
 ### Response Structure
 
 - **Success (200):** Returns room preview data in the format above


### PR DESCRIPTION
## Summary
Adds content filtering for `m.room.join_rules` state events to only expose the `join_rule` key, stripping out all other keys (like `allow` for restricted rooms) for security and privacy.

## Changes
- ✅ Add `_filter_join_rules_content()` function to filter join_rules events
- ✅ Apply filter when processing state events
- ✅ Add 4 E2E tests (SQLite + PostgreSQL) to verify filtering behavior
- ✅ Update README with documentation
- ✅ Fix typo in existing code

## Testing
All 20 tests passing (including 4 new tests for join_rules filtering)

```
Ran 20 tests in 98.570s
PASSED (successes=20)
```