### PR TITLE
Add membership_summary support for course rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,22 @@ The module exposes a REST endpoint at `/_synapse/client/unstable/org.pangea/room
 
 #### Membership Summary
 
-When a room contains `pangea.activity_roles` state events, the response includes a `membership_summary` field that maps user IDs (referenced in activity roles) to their current membership status (e.g., `"join"`, `"leave"`, `"invite"`, `"ban"`, `"knock"`).
+The response includes a `membership_summary` field for rooms that contain either:
+- `pangea.activity_roles` state events (activity rooms), or
+- `pangea.course_plan` state events (course rooms)
+
+The `membership_summary` maps user IDs to their current membership status (e.g., `"join"`, `"leave"`, `"invite"`, `"ban"`, `"knock"`).
+
+**For activity rooms** (with `pangea.activity_roles`): The membership summary only includes users who are referenced in the activity roles. This allows clients to determine who has left the room while still seeing all roles (including those of users who have left).
+
+**For course rooms** (with `pangea.course_plan` but without `pangea.activity_roles`): The membership summary includes all users in the room, allowing clients to see the current membership state of the course.
 
 This allows clients to:
 - Display information about completed activities, including roles of users who have left
 - Filter out users who have left when displaying open/active rooms
+- Track course membership status
 
-**Backwards Compatibility:** The `membership_summary` field is additive and only appears when activity roles are present. Existing clients that don't use this field will continue to work without modification, as the core response structure remains unchanged.
+**Backwards Compatibility:** The `membership_summary` field is additive and only appears when activity roles or course plan state events are present. Existing clients that don't use this field will continue to work without modification, as the core response structure remains unchanged.
 
 #### Content Filtering for m.room.join_rules
 


### PR DESCRIPTION
## Summary
This PR extends the `membership_summary` feature to also work with course rooms (rooms containing the `pangea.course_plan` state event).

## Changes
- Modified `_add_membership_summary()` to support both activity rooms and course rooms
- Added import for `PANGEA_COURSE_PLAN_STATE_EVENT_TYPE` constant
- Added comprehensive tests for both SQLite and PostgreSQL databases
- Updated README documentation to describe the new behavior

## Behavior

### Activity rooms (`pangea.activity_roles`)
The `membership_summary` contains only users referenced in the activity roles. This allows clients to show role information even for users who have left the room.

### Course rooms (`pangea.course_plan` without `pangea.activity_roles`)
The `membership_summary` contains all room members. This allows clients to track the current membership state of course rooms.

### Regular rooms (neither)
No `membership_summary` field is added (existing behavior).

## Testing
- ✅ Added `test_course_plan_with_membership_summary_sqlite`
- ✅ Added `test_course_plan_with_membership_summary_postgres`
- ✅ All 25 tests pass
- ✅ Backwards compatible - existing clients will continue to work

## Backwards Compatibility
The `membership_summary` field is additive and only appears when `pangea.course_plan` or `pangea.activity_roles` state events are present. Existing clients that don't use this field will continue to work without modification.